### PR TITLE
Add ttfautohint manual compile at latest version 1.3

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,9 +6,39 @@ FROM ruby:2.1
 # the node image, as the ruby base image is more complex 
 #  to duplicate
 
-# Install fontforge and ttfautohint for webfont compiling.
-# TODO: build latest version of ttfautohint from source
-RUN apt-get update && apt-get install -y fontforge ttfautohint=0.97-1 && rm -rf /var/lib/apt/lists/*
+# Install ttfautohint for webfont compiling.
+ENV HARFBUZZ_VERSION 0.9.40
+ENV TTFAUTOHINT_VERSION 1.3
+
+# RUN apt-get install qt4 needed by ttfautohint
+RUN apt-get update && \
+    apt-get install -y qt4-dev-tools \
+    && rm -rf /var/lib/apt/lists/*
+
+# compile and install harfbuzz (needed by ttfautohint)
+RUN curl -SLO "http://www.freedesktop.org/software/harfbuzz/release/harfbuzz-$HARFBUZZ_VERSION.tar.bz2" \
+    && mkdir -p /usr/src/harfbuzz \
+    && tar -xjf "harfbuzz-$HARFBUZZ_VERSION.tar.bz2" -C /usr/src/harfbuzz --strip-components=1 \
+    && rm "harfbuzz-$HARFBUZZ_VERSION.tar.bz2" \
+    && cd /usr/src/harfbuzz \
+    && ./configure \
+    && make \
+    && make install \
+    && rm -rf /usr/src/harfbuzz
+
+# compile and install ttfautohint
+RUN curl -SLO "http://download.savannah.gnu.org/releases/freetype/ttfautohint-$TTFAUTOHINT_VERSION.tar.gz" \
+    && mkdir -p /usr/src/ttfautohint \
+    && tar -xzf "ttfautohint-$TTFAUTOHINT_VERSION.tar.gz" -C /usr/src/ttfautohint --strip-components=1 \
+    && rm "ttfautohint-$TTFAUTOHINT_VERSION.tar.gz" \
+    && cd /usr/src/ttfautohint \
+    && ./configure \
+    && make \
+    && make install \
+    && rm -rf /usr/src/ttfautohint
+
+# Install fontforge
+RUN apt-get update && apt-get install -y fontforge && rm -rf /var/lib/apt/lists/*
 
 # Install Node to run grunt. Copied from the official node docker image.
 # https://github.com/joyent/docker-node/blob/3bb9c7ba9eb2360a031717b146747eea781abfab/0.12/Dockerfile


### PR DESCRIPTION
This installs the latest version of ttfautohint by downloading and compiling instead of using apt-get. The version in the apt-get repo was old and generated memory errors during operation.
